### PR TITLE
Add adapter tests

### DIFF
--- a/mindie_turbo/adapter/sglang_turbo/__init__.py
+++ b/mindie_turbo/adapter/sglang_turbo/__init__.py
@@ -1,1 +1,1 @@
-"""sglang_turbo package"""
+from .zip import zip, unzip

--- a/mindie_turbo/adapter/sglang_turbo/setup.py
+++ b/mindie_turbo/adapter/sglang_turbo/setup.py
@@ -4,4 +4,5 @@ setup(
     name="sglang_turbo",
     version="0.1.0",
     packages=find_packages(include=["sglang_turbo", "sglang_turbo.*"]),
+    install_requires=["mindie_turbo"],
 )

--- a/mindie_turbo/adapter/vllm_turbo/__init__.py
+++ b/mindie_turbo/adapter/vllm_turbo/__init__.py
@@ -1,1 +1,1 @@
-"""vllm_turbo package"""
+from .zip import zip, unzip

--- a/mindie_turbo/adapter/vllm_turbo/setup.py
+++ b/mindie_turbo/adapter/vllm_turbo/setup.py
@@ -4,4 +4,5 @@ setup(
     name="vllm_turbo",
     version="0.1.0",
     packages=find_packages(include=["vllm_turbo", "vllm_turbo.*"]),
+    install_requires=["mindie_turbo"],
 )

--- a/mindie_turbo/adapter/vllm_turbo/zip.py
+++ b/mindie_turbo/adapter/vllm_turbo/zip.py
@@ -1,0 +1,11 @@
+from mindie_turbo.multimodal import zip as mm_zip, unzip as mm_unzip
+
+
+def zip(a, b):
+    print(f'Zipping {a} and {b} in vllm_turbo')
+    return mm_zip(a, b)
+
+
+def unzip(a):
+    print(f'Unzipping {a} in vllm_turbo')
+    return mm_unzip(a)

--- a/tests/test_mmzip.py
+++ b/tests/test_mmzip.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mindie_turbo.multimodal import zip as mm_zip, unzip as mm_unzip
+
+
+def test_mmzip_roundtrip():
+    a = "hello"
+    b = "world"
+    zipped = mm_zip(a, b)
+    assert zipped == a + b
+    assert mm_unzip(zipped) == (a, b)

--- a/tests/test_sglang_turbo.py
+++ b/tests/test_sglang_turbo.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mindie_turbo.adapter.sglang_turbo.zip import zip as sg_zip, unzip as sg_unzip
+
+
+def test_sglang_zip_roundtrip(capsys):
+    a = "foo"
+    b = "bar"
+    zipped = sg_zip(a, b)
+    captured = capsys.readouterr()
+    assert "sglang_turbo" in captured.out
+    assert zipped == a + b
+    assert sg_unzip(zipped) == (a, b)

--- a/tests/test_vllm_turbo.py
+++ b/tests/test_vllm_turbo.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from mindie_turbo.adapter.vllm_turbo.zip import zip as vl_zip, unzip as vl_unzip
+
+
+def test_vllm_zip_roundtrip(capsys):
+    a = "baz"
+    b = "qux"
+    zipped = vl_zip(a, b)
+    captured = capsys.readouterr()
+    assert "vllm_turbo" in captured.out
+    assert zipped == a + b
+    assert vl_unzip(zipped) == (a, b)


### PR DESCRIPTION
## Summary
- export `zip`/`unzip` in adapter packages
- make adapter packages depend on `mindie_turbo`
- implement `vllm_turbo.zip`
- create separate tests for `mmzip`, `sglang_turbo`, and `vllm_turbo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527f564cc083229bd15a96224f5e14