### PR TITLE
Add unified logging and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.log
+*.egg-info/

--- a/mindie_turbo/adapter/sglang_turbo/zip.py
+++ b/mindie_turbo/adapter/sglang_turbo/zip.py
@@ -1,11 +1,14 @@
 from mindie_turbo.multimodal import zip as mm_zip, unzip as mm_unzip
+from mindie_turbo.logger import get_logger
+
+logger = get_logger("sglang_turbo")
 
 
 def zip(a, b):
-    print(f'Zipping {a} and {b} in sglang_turbo')
+    logger.info(f"Zipping {a} and {b} in sglang_turbo")
     return mm_zip(a, b)
 
 
 def unzip(a):
-    print(f'Unzipping {a} in sglang_turbo')
+    logger.info(f"Unzipping {a} in sglang_turbo")
     return mm_unzip(a)

--- a/mindie_turbo/adapter/vllm_turbo/zip.py
+++ b/mindie_turbo/adapter/vllm_turbo/zip.py
@@ -1,11 +1,14 @@
 from mindie_turbo.multimodal import zip as mm_zip, unzip as mm_unzip
+from mindie_turbo.logger import get_logger
+
+logger = get_logger("vllm_turbo")
 
 
 def zip(a, b):
-    print(f'Zipping {a} and {b} in vllm_turbo')
+    logger.info(f"Zipping {a} and {b} in vllm_turbo")
     return mm_zip(a, b)
 
 
 def unzip(a):
-    print(f'Unzipping {a} in vllm_turbo')
+    logger.info(f"Unzipping {a} in vllm_turbo")
     return mm_unzip(a)

--- a/mindie_turbo/logger.py
+++ b/mindie_turbo/logger.py
@@ -1,0 +1,26 @@
+import logging
+import sys
+from pathlib import Path
+
+_LOG_FILE = Path(__file__).resolve().parent / "app.log"
+
+
+def get_logger(package_name: str) -> logging.Logger:
+    logger = logging.getLogger(package_name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        fmt="%(name)s - %(filename)s:%(lineno)d - %(message)s"
+    )
+
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    file_handler = logging.FileHandler(_LOG_FILE)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+
+    return logger

--- a/mindie_turbo/multimodal/mmzip.py
+++ b/mindie_turbo/multimodal/mmzip.py
@@ -1,8 +1,13 @@
+from mindie_turbo.logger import get_logger
+
+logger = get_logger("mindie_turbo")
+
+
 def zip(a, b):
-    print(f'Zipping {a} and {b}')
-    return a+b
+    logger.info(f"Zipping {a} and {b}")
+    return a + b
 
 
 def unzip(a):
-    print(f'Unzipping {a}')
-    return a[:len(a)//2], a[len(a)//2:]
+    logger.info(f"Unzipping {a}")
+    return a[: len(a) // 2], a[len(a) // 2 :]

--- a/tests/test_sglang_turbo.py
+++ b/tests/test_sglang_turbo.py
@@ -4,13 +4,14 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mindie_turbo.adapter.sglang_turbo.zip import zip as sg_zip, unzip as sg_unzip
+import logging
 
 
-def test_sglang_zip_roundtrip(capsys):
-    a = "foo"
-    b = "bar"
-    zipped = sg_zip(a, b)
-    captured = capsys.readouterr()
-    assert "sglang_turbo" in captured.out
+def test_sglang_zip_roundtrip(caplog):
+    with caplog.at_level(logging.INFO):
+        a = "foo"
+        b = "bar"
+        zipped = sg_zip(a, b)
+    assert "sglang_turbo" in caplog.text
     assert zipped == a + b
     assert sg_unzip(zipped) == (a, b)

--- a/tests/test_vllm_turbo.py
+++ b/tests/test_vllm_turbo.py
@@ -4,13 +4,14 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mindie_turbo.adapter.vllm_turbo.zip import zip as vl_zip, unzip as vl_unzip
+import logging
 
 
-def test_vllm_zip_roundtrip(capsys):
-    a = "baz"
-    b = "qux"
-    zipped = vl_zip(a, b)
-    captured = capsys.readouterr()
-    assert "vllm_turbo" in captured.out
+def test_vllm_zip_roundtrip(caplog):
+    with caplog.at_level(logging.INFO):
+        a = "baz"
+        b = "qux"
+        zipped = vl_zip(a, b)
+    assert "vllm_turbo" in caplog.text
     assert zipped == a + b
     assert vl_unzip(zipped) == (a, b)


### PR DESCRIPTION
## Summary
- create reusable logger that logs package name, file, and line
- use new logger in `mmzip`, `sglang_turbo`, and `vllm_turbo`
- update tests to capture logging output
- ignore build artifacts and log files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68528e2bf7dc83228461792922a352bb