### PR TITLE
Add poetry configs for package builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # build_test
+
+This repository contains three Python packages:
+
+- `mindie_turbo`: the core utilities.
+- `sglang_turbo`: an adapter depending on `mindie_turbo`.
+- `vllm_turbo`: another adapter depending on `mindie_turbo`.
+
+Each package now includes a `pyproject.toml` so you can build wheels with
+[Poetry](https://python-poetry.org/).
+
+## Building the packages
+
+1. Install Poetry if you don't have it:
+   ```bash
+   pip install poetry
+   ```
+2. From the repository root, run the following commands to build each
+   package individually:
+   ```bash
+   poetry build
+   (cd mindie_turbo/adapter/sglang_turbo && poetry build)
+   (cd mindie_turbo/adapter/vllm_turbo && poetry build)
+   ```
+   The generated wheels will be placed in each package's `dist/` directory.

--- a/mindie_turbo/adapter/sglang_turbo/pyproject.toml
+++ b/mindie_turbo/adapter/sglang_turbo/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "sglang_turbo"
+version = "0.1.0"
+description = "SGLang adapter utilities"
+packages = [{ include = "sglang_turbo" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+mindie_turbo = "^0.1.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/mindie_turbo/adapter/vllm_turbo/pyproject.toml
+++ b/mindie_turbo/adapter/vllm_turbo/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.poetry]
+name = "vllm_turbo"
+version = "0.1.0"
+description = "VLLM adapter utilities"
+packages = [{ include = "vllm_turbo" }]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+mindie_turbo = "^0.1.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.poetry]
+name = "mindie_turbo"
+version = "0.1.0"
+description = "Core utilities for the mindie_turbo package"
+packages = [
+    { include = "mindie_turbo", exclude = ["adapter", "adapter.*"] }
+]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` for the `mindie_turbo` package
- add Poetry build files for adapter packages
- document how to build all packages with Poetry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853bc7f69a88322b9b817ab806c8c29