### PR TITLE
Update build script for multi-package compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 *.log
 *.egg-info/
+build/

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,46 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-python setup.py bdist_wheel
+# Root build directory
+BUILD_DIR="$(dirname "$0")/build"
+
+# Packages to build
+PACKAGES=(
+    "."
+    "mindie_turbo/adapter/sglang_turbo"
+    "mindie_turbo/adapter/vllm_turbo"
+)
+
+# Prepare build directory
+if [ -d "$BUILD_DIR" ] && [ "$(ls -A "$BUILD_DIR" 2>/dev/null)" ]; then
+    echo "Performing incremental build in $BUILD_DIR"
+else
+    echo "Performing full rebuild"
+    rm -rf "$BUILD_DIR"
+    mkdir -p "$BUILD_DIR"
+fi
+
+# Build each package and move wheels into build directory
+for pkg in "${PACKAGES[@]}"; do
+    echo "Building package $pkg"
+    pkg_name=$(basename "$pkg")
+    tmp_dir="build_temp_${pkg_name//\./_}"
+    (cd "$pkg" && python setup.py build --build-base "$tmp_dir" \
+        bdist_wheel -b "$tmp_dir/bdist" -d dist)
+    rm -rf "$pkg/$tmp_dir" "$pkg/tmp_build" "$pkg/tmp_bdist"
+
+    for whl in "$pkg"/dist/*.whl; do
+        [ -e "$whl" ] || continue
+        dest="$BUILD_DIR/$(basename "$whl")"
+        if [ -f "$dest" ]; then
+            if cmp -s "$whl" "$dest"; then
+                echo "Artifact $(basename "$whl") is up to date"
+                continue
+            fi
+        fi
+        echo "Updating $(basename "$whl")"
+        cp "$whl" "$dest"
+    done
+    rm -rf "$pkg"/dist "$pkg"/*.egg-info
+done
 


### PR DESCRIPTION
## Summary
- compile all packages via build.sh
- copy wheel artifacts to root build directory
- ignore build artifacts in git

## Testing
- `pytest -q`
- `bash build.sh > /tmp/build.log`

------
https://chatgpt.com/codex/tasks/task_e_6853be9de2448322837047f2e189b4d4