### PR TITLE
Remove unused build scripts

### DIFF
--- a/mindie_turbo/adapter/sglang_turbo/build.sh
+++ b/mindie_turbo/adapter/sglang_turbo/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-python setup.py bdist_wheel

--- a/mindie_turbo/adapter/vllm_turbo/build.sh
+++ b/mindie_turbo/adapter/vllm_turbo/build.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-python setup.py bdist_wheel


### PR DESCRIPTION
## Summary
- remove redundant build scripts in `sglang_turbo` and `vllm_turbo`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c60fa4188322b6acddb69ea783e2